### PR TITLE
Add Dockerfile and serve frontend from backend

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+# Use official Node.js image as the base
+FROM node:20-alpine as build
+
+# Set working directory
+WORKDIR /app
+
+# Copy frontend files and install dependencies
+COPY frontend ./frontend
+WORKDIR /app/frontend
+RUN npm install && npm run build
+
+# Copy backend files and install dependencies
+WORKDIR /app
+COPY backend ./backend
+COPY backend/package.json ./backend/package.json
+COPY backend/package-lock.json ./backend/package-lock.json
+RUN cd backend && npm install
+
+# Copy frontend build to backend
+RUN cp -r /app/frontend/dist /app/backend/
+
+# Set working directory to backend
+WORKDIR /app/backend
+
+# Expose port (change if your backend uses a different port)
+EXPOSE 3000
+
+# Start the backend server
+CMD ["node", "index.js"]

--- a/backend/index.js
+++ b/backend/index.js
@@ -35,13 +35,14 @@ app.use(cors({
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 
+// Serve frontend static files
+const path = require('path');
+const frontendBuildPath = path.join(__dirname, '../frontend/dist');
+app.use(express.static(frontendBuildPath));
+
 // Health check endpoint for deployment platforms
 app.get('/', (req, res) => {
-    res.json({ 
-        message: 'RiseOZ Backend API is running!',
-        status: 'healthy',
-        timestamp: new Date().toISOString()
-    });
+    res.sendFile(path.join(frontendBuildPath, 'index.html'));
 });
 
 // ROUTES


### PR DESCRIPTION
Introduces a Dockerfile to build and run both frontend and backend in a single container. Updates backend to serve the frontend static files and index.html for the root route, enabling unified deployment.